### PR TITLE
elan: Add support for touch devices

### DIFF
--- a/libfprint/drivers/aes3k.c
+++ b/libfprint/drivers/aes3k.c
@@ -121,7 +121,7 @@ img_cb (FpiUsbTransfer *transfer, FpDevice *device,
 
   /* FIXME: this is an ugly hack to make the image big enough for NBIS
    * to process reliably */
-  img = fpi_image_resize (tmp, cls->enlarge_factor, cls->enlarge_factor);
+  img = fpi_image_resize (tmp, cls->enlarge_factor, cls->enlarge_factor, FALSE);
   g_object_unref (tmp);
   fpi_image_device_image_captured (dev, img);
 

--- a/libfprint/drivers/elan_touch.c
+++ b/libfprint/drivers/elan_touch.c
@@ -1,0 +1,101 @@
+/*
+ * Elan driver for libfprint
+ *
+ * Copyright (C) 2017 Igor Filatov <ia.filatov@gmail.com>
+ * Copyright (C) 2018 Sébastien Béchet <sebastien.bechet@osinix.com >
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * The algorithm which libfprint uses to match fingerprints doesn't like small
+ * images like the ones these drivers produce. There's just not enough minutiae
+ * (recognizable print-specific points) on them for a reliable match. This means
+ * that unless another matching algo is found/implemented, these readers will
+ * not work as good with libfprint as they do with vendor drivers.
+ *
+ * To get bigger images the driver expects you to swipe the finger over the
+ * reader. This works quite well for readers with a rectangular 144x64 sensor.
+ * Worse than real swipe readers but good enough for day-to-day use. It needs
+ * a steady and relatively slow swipe. There are also square 96x96 sensors and
+ * I don't know whether they are in fact usable or not because I don't have one.
+ * I imagine they'd be less reliable because the resulting image is even
+ * smaller. If they can't be made usable with libfprint, I might end up dropping
+ * them because it's better than saying they work when they don't.
+ */
+
+#define FP_COMPONENT "elan_touch"
+
+#include "drivers_api.h"
+#include "elan.h"
+
+struct _FpiDeviceElanTouch
+{
+  FpiDeviceElan parent;
+};
+G_DECLARE_FINAL_TYPE (FpiDeviceElanTouch, fpi_device_elan_touch, FPI,
+                      DEVICE_ELAN_TOUCH, FpiDeviceElan);
+G_DEFINE_TYPE (FpiDeviceElanTouch, fpi_device_elan_touch, FPI_TYPE_DEVICE_ELAN);
+
+static const FpIdEntry id_table[] = {
+  { .vid = 0x04f3, .pid = 0x0c28 },
+  { .vid = 0,  .pid = 0,  .driver_data = 0 },
+};
+
+static void
+elan_touch_submit_image (FpImageDevice *dev)
+{
+  FpiDeviceElanClass *self = FPI_DEVICE_ELAN_GET_CLASS (FPI_DEVICE_ELAN (dev));
+  GSList *raw_frames = NULL;
+  FpImage *img, *tmp;
+
+  G_DEBUG_HERE ();
+
+  // Prefer the middle frame
+  raw_frames = g_slist_prepend (raw_frames, g_slist_nth_data (self->frames, g_slist_length (self->frames) / 2));
+  tmp = self->assemble_image (self, raw_frames, self->frame_width);
+  /* Make the image big enough for NBIS to process reliably */
+  img = fpi_image_resize (tmp, 2, 2, TRUE);
+  g_object_unref (tmp);
+
+  g_slist_free (raw_frames);
+  fpi_image_device_image_captured (dev, img);
+}
+
+static void
+fpi_device_elan_touch_init (FpiDeviceElanTouch *self)
+{
+}
+
+static void
+fpi_device_elan_touch_class_init (FpiDeviceElanTouchClass *klass)
+{
+  FpDeviceClass *dev_class = FP_DEVICE_CLASS (klass);
+  FpiDeviceElanClass *elan_class = FPI_DEVICE_ELAN_CLASS (klass);
+  FpImageDeviceClass *img_class = FP_IMAGE_DEVICE_CLASS (klass);
+
+  dev_class->id = "elan_touch";
+  dev_class->full_name = "ElanTech Fingerprint Sensor";
+  dev_class->id_table = id_table;
+  dev_class->scan_type = FP_SCAN_TYPE_PRESS;
+
+  /* Low due to low image quality. */
+  img_class->bz3_threshold = 9;
+
+  elan_class->min_frames = ELAN_TOUCH_MIN_FRAMES;
+  elan_class->max_frames = ELAN_TOUCH_MAX_FRAMES;
+  elan_class->max_frame_height = ELAN_TOUCH_MAX_FRAME_HEIGHT;
+  elan_class->submit_image = elan_touch_submit_image;
+}

--- a/libfprint/fpi-image.h
+++ b/libfprint/fpi-image.h
@@ -80,5 +80,6 @@ gint fpi_mean_sq_diff_norm (const guint8 *buf1,
 #if HAVE_PIXMAN
 FpImage *fpi_image_resize (FpImage *orig,
                            guint    w_factor,
-                           guint    h_factor);
+                           guint    h_factor,
+                           gboolean enhance);
 #endif

--- a/libfprint/meson.build
+++ b/libfprint/meson.build
@@ -150,7 +150,10 @@ foreach driver: drivers
         drivers_sources += [ 'drivers/vfs0050.c' ]
     endif
     if driver == 'elan'
-        drivers_sources += [ 'drivers/elan.c' ]
+        drivers_sources += [ 'drivers/elan.c', 'drivers/elan_touch.c' ]
+    endif
+    if driver == 'elan_touch'
+        drivers_sources += [ 'drivers/elan_touch.c' ]
     endif
     if driver == 'virtual_image'
         drivers_sources += [ 'drivers/virtual-image.c' ]

--- a/meson.build
+++ b/meson.build
@@ -106,6 +106,7 @@ default_drivers = [
     'vcom5s',
     'synaptics',
     'elan',
+    'elan_touch',
     'uru4000',
     'upektc',
     'upeksonly',
@@ -137,7 +138,7 @@ foreach driver: drivers
             error('NSS is required for the URU4000/URU4500 driver')
         endif
     endif
-    if driver == 'aes3500' or driver == 'aes4000'
+    if driver == 'aes3500' or driver == 'aes4000' or driver == 'elan_touch'
         imaging_dep = dependency('pixman-1', required: false)
         if not imaging_dep.found()
             error('pixman is required for imaging support')


### PR DESCRIPTION
Despite being listed in the supported devices my Elan reader (0x0c28) can be hardly used with libfrint currently.
Here is my attempt at addressing the issues and making the reader usable.
Some obvious changes are based directly on https://github.com/iafilatov/libfprint/tree/elan-touch. 
Other noteworthy changes:
* The number of calibration loops was increased as otherwise it was not possible to complete the enrollment at all (it fails at every second capture)
* Some handling for 0xaf was added CAPTURE_READ_DATA; I do not know what the code means but it is return relatively often and prevents the enrollment from completion
* bz3_threshold was decreased due to the reader's low resolution and poor image quality
* the original image is resized to make minutiae extraction work (resizing is enough to extract a bunch of minutiae from a single frame)
* a simple sharpening convolution filter is applied to the resized image to improve minutiae extraction (usually doubles the number of extracted minutiae)

Even if you decide not to include the whole PR I would like to ask you to consider increasing the number of calibration loops and adding some handling for the 0xaf result code as otherwise it is literaly impossible to enroll even in the swipe mode.